### PR TITLE
Allow long names when reading header

### DIFF
--- a/minexr/reader.py
+++ b/minexr/reader.py
@@ -94,7 +94,8 @@ class MinExrReader:
         # Magic and version and info bits
         magic, version, b2, b3, b4 = struct.unpack('<iB3B', buf.read(8))
         assert magic == 20000630, 'Not an OpenEXR file.'
-        assert b2 == b3 == b4 == 0, 'Not a single-part scan line file.'
+        assert b2 in (0, 4), 'Not a single-part scan line file.'
+        assert b3 == b4 == 0, 'Unused flags in version field are not zero.'
 
         # Header attributes
         self.attrs = self._read_header_attrs(buf)


### PR DESCRIPTION
Reading headers currently fails if byte 2 is not 0 as an attempt to exclude files that aren't single-part scan line files. 
However, if my understanding of the spec (page 6 at https://www.openexr.com/documentation/openexrfilelayout.pdf) is correct, b2 can also be equal to 4, which only indicates long attribute and channel names rather than any differences in how the data is structured. We seem to be able to deal with varying name lengths already, so no exception should be raised in this case. You might want to do some testing first to confirm that this is the case, though.

This should enable minexr to read exr files exported by cycles, since this seems to be the main difference compared to eevee.